### PR TITLE
Item cooldown tracking (bags, equipped, trinkets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,14 @@
 - Learning new AuraDuration gets prematurely completed if another player's aura with the same name runs out on the same target before yours - no way to get casterID when an aura fades.
 - Skills that apply Auras with the same name may show "learning" all the time (maybe this one is fixed now - wasn't able to test yet).
 - Having more than 16 auras shows auras outside the GUI frame (scrollframe possible, but then has more/other issues)
+- AddOn is kinda heavy on ressources (compared to other addons), will optimize in a future update.
 - /sa learnall 1 tries to learn spells without aura (i.e. smite, shadowbolt, etc.)
-- Reactive Spells require manual duration setup - no auto-learning available (Vanilla API limitation)
 
 
 ## Console Commands:
 /sa or /sa show or /sa hide - Show/hide simpleAuras Settings.
 
-/sa refresh X - Set aura data scan rate. (1 to 10 scans per second. Default: 5). GUI always renders at 20 FPS.
-
-### Reactive Spells (Surprise Attack, Overpower, etc):
-/sa reactduration SpellName Duration - manually set reactive spell duration (REQUIRED for reactive spells to work).
-
-/sa reactduration SpellID Duration - or use spell ID instead of name.
-
-/sa forget react SpellName - forget reactive spell duration (or 'all' to delete all).
-
-**Example:** /sa reactduration Surprise Attack 5
-
-
+/sa refresh X - Set refresh rate. (1 to 10 updates per second. Default: 5).
 
 ### SuperWoW commands:
 /sa learn X Y - manually set duration Y of spellID X.
@@ -85,8 +74,8 @@ Icon/Texture:
 
 
 Conditions:
-- Unit: Which unit the aura is on (Player/Target).
-- Type: Buff, Debuff, Cooldown, or Reactive.
+- Unit: Which unit the aura is on.
+- Type: is it a buff or a debuff.
 - Low Duration Color*: If the auracolor should change at or below "lowduration"
 - Low Duration in secs*: Allways active, changes durationcolor to red if at or below, also changes color if activated.
 - In/Out of Combat: When aura should be shown
@@ -100,13 +89,7 @@ Cooldown:
 - Always: Shows Cooldown Icon if it's on CD or not.
 - No CD: Show when not on CD.
 - CD: Show when on CD.
-
-Reactive:
-- Tracks proc-based abilities (Riposte, Overpower, Revenge, Surprise Attack, etc).
-- **IMPORTANT:** You MUST set duration manually using `/sa reactduration SpellName Duration`.
-- Shows timer when proc is active.
-- Automatically refreshes on repeated procs.
-- Examples: Riposte (5s), Overpower (5s), Surprise Attack (6s).
+- Equipped: Enable red warning color when item is in bags instead of equipped (useful for trinkets).
 
 
 Other:
@@ -117,6 +100,8 @@ Other:
 \* = For these functions to work on targets SuperWoW is REQUIRED! Also only shows your own AuraDurations.
 
 
+<<<<<<< Updated upstream
+=======
 ## Reactive Spells Setup (Riposte, Overpower, etc)
 
 Reactive spells are proc-based abilities that become available after specific events (dodge, parry, block). Unlike buffs and cooldowns, they require **manual duration setup**.
@@ -132,7 +117,7 @@ Reactive spells are proc-based abilities that become available after specific ev
 2. **Set duration manually (REQUIRED):**
    ```
    /sa reactduration Riposte 5
-   /sa reactduration "Surprise Attack" 6
+   /sa reactduration Surprise Attack 4
    ```
    Or use spell ID:
    ```
@@ -155,6 +140,25 @@ Reactive spells are proc-based abilities that become available after specific ev
 - **Manual duration required:** Vanilla API doesn't provide proc expiration events.
 - **Refresh detection:** `COMBAT_TEXT_UPDATE` only fires when ability *becomes* available, not on subsequent procs while already active. This means not all repeated procs within the duration window will be detected for refresh.
 - **Workaround:** For 100% proc tracking, you could extend the code to parse `CHAT_MSG_COMBAT_SELF_MISSES` for dodge/parry/block events and manually refresh timers.
+
+## Cooldown Tracking
+
+simpleAuras tracks cooldowns for:
+- **Spells** from your spellbook
+- **Items** in your bags (potions, food, etc)
+- **Equipped items** (trinkets, engineering items, etc)
+
+### Item Cooldown Features:
+- **Auto-detection:** Automatically finds items in bags and equipped slots
+- **Smart caching:** Remembers itemID for continued tracking even when item is consumed
+- **Equipped warning:** Enable "Equipped" checkbox for trinkets/items to show red warning when item is in bags instead of equipped
+- **Works with:** Trinkets, engineering items, potions, bandages, and any usable items
+
+### Setup Example (Trinket):
+1. Create aura: Type `Cooldown`, Name: exact item name (e.g., `Earthstrike`)
+2. Enable `Autodetect` to get icon automatically
+3. Enable `Equipped` checkbox to get red warning when trinket is in bag
+4. Set show condition: `Always`, `CD`, or `No CD`
 
 ## SuperWoW Features
 If SuperWoW is installed, simpleAuras will automatically learn unkown durations of most of **your own** auras with the first cast (needs to run out to be accurate).

--- a/simpleAuras.toc
+++ b/simpleAuras.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: |c194b7dccsimple|cffffffffAuras
 ## Notes: Simple Aura Display. /sa help
-## Version: 1.2
+## Version: 1.3
 ## Author: yani9o
 ## SavedVariablesPerCharacter: simpleAuras
 init.lua


### PR DESCRIPTION
- Add cooldown tracking for items in bags via GetContainerItemCooldown
- Add cooldown tracking for equipped items via GetInventoryItemCooldown
- Add "Equipped" checkbox to warn when item should be equipped but is in bag
- Implement itemID caching for persistent tracking when items are consumed
- Parse itemLink directly to avoid GetItemInfo async issues
- Add events: BAG_UPDATE, BAG_UPDATE_COOLDOWN, UNIT_INVENTORY_CHANGED

Fixes item cooldown detection for potions, trinkets, and engineering items.